### PR TITLE
Remove TSC_NONPOLLING_WATCHER  environment variable from banner

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env TSC_NONPOLLING_WATCHER=1 node --max-old-space-size=8192
+#!/usr/bin/env node --max-old-space-size=8192
 
 // Usage: build.js [-w [-clean]]
 //        build.js -O [-nominify]
@@ -304,7 +304,7 @@ const rin = {
 let versionBanner = `/* ${pkg.name} ${VERSION_WITH_TAG} */\n`
 let execBanner = ""
 if (productIsExectuable) {
-  execBanner = '#!/usr/bin/env TSC_NONPOLLING_WATCHER=1 node\n'
+  execBanner = '#!/usr/bin/env node\n'
 }
 const wrapperStart = '(function(global){\n'
 const wrapperEnd = '\n})(typeof exports != "undefined" ? exports : this);\n'


### PR DESCRIPTION
Including environment variables as part of the shebang does not appear to be valid on all systems. 

https://github.com/rsms/figplug/issues/9 describes an issue on both Windows 10 (another user) and an issue I ran into when using `pnpm`.

https://github.com/pnpm/pnpm/issues/5170 was opened on `pnpm` but it doesn't sound like this is valid and won't be handled.

This pull request proposes removing this environment variable so this is usable on all systems.

Let me know if I need to make any more changes, thanks!